### PR TITLE
Initialize Next.js recipe app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+public

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,13 +1,29 @@
 {
   "name": "recipe",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "^2.39.5"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.34",
+    "tailwindcss": "^3.4.4",
+    "typescript": "5.4.5",
+    "@types/react": "18.2.14",
+    "@types/node": "20.11.19",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.2.3",
+    "prettier": "3.2.5"
+  },
   "packageManager": "pnpm@9.15.4"
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_req: Request, { params }: Params) {
+  const { data, error } = await supabase
+    .from('recipes')
+    .select('*')
+    .eq('id', params.id)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const name = formData.get('name') as string;
+  const ingredients = formData.get('ingredients') as string;
+  const steps = formData.get('steps') as string;
+  const file = formData.get('image') as File | null;
+
+  let imageUrl = '';
+
+  if (file) {
+    const { data, error } = await supabase.storage
+      .from('recipe-images')
+      .upload(`${Date.now()}-${file.name}`, file, {
+        cacheControl: '3600',
+      });
+
+    if (error || !data) {
+      return NextResponse.json({ success: false, error }, { status: 500 });
+    }
+
+    const { data: urlData } = await supabase.storage
+      .from('recipe-images')
+      .getPublicUrl(data.path);
+    imageUrl = urlData.publicUrl;
+  }
+
+  const { data: insertData, error: insertError } = await supabase
+    .from('recipes')
+    .insert({ name, ingredients, steps, imageUrl })
+    .select()
+    .single();
+
+  if (insertError || !insertData) {
+    return NextResponse.json({ success: false, error: insertError }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, recipeId: insertData.id });
+}
+
+export async function GET() {
+  const { data, error } = await supabase
+    .from('recipes')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Recipe App',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-100 text-gray-900">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/new-recipe/page.tsx
+++ b/src/app/new-recipe/page.tsx
@@ -1,0 +1,10 @@
+import RecipeForm from '@/components/RecipeForm';
+
+export default function NewRecipePage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">新增食譜</h1>
+      <RecipeForm />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,19 @@
+import RecipeList from '@/components/RecipeList';
+import { Recipe } from '@/types/recipe';
+
+async function getRecipes(): Promise<Recipe[]> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/recipes`, {
+    cache: 'no-store',
+  });
+  return res.json();
+}
+
+export default async function Home() {
+  const recipes = await getRecipes();
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">食譜列表</h1>
+      <RecipeList recipes={recipes} />
+    </main>
+  );
+}

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -1,0 +1,22 @@
+import RecipeDetail from '@/components/RecipeDetail';
+import { Recipe } from '@/types/recipe';
+
+interface Props {
+  params: { id: string };
+}
+
+async function getRecipe(id: string): Promise<Recipe> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/recipes/${id}`, {
+    cache: 'no-store',
+  });
+  return res.json();
+}
+
+export default async function RecipeDetailPage({ params }: Props) {
+  const recipe = await getRecipe(params.id);
+  return (
+    <main className="p-4">
+      <RecipeDetail recipe={recipe} />
+    </main>
+  );
+}

--- a/src/components/RecipeDetail.tsx
+++ b/src/components/RecipeDetail.tsx
@@ -1,0 +1,21 @@
+import Image from 'next/image';
+import { Recipe } from '@/types/recipe';
+
+export default function RecipeDetail({ recipe }: { recipe: Recipe }) {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{recipe.name}</h1>
+      {recipe.imageUrl && (
+        <Image src={recipe.imageUrl} alt={recipe.name} width={600} height={400} />
+      )}
+      <div>
+        <h2 className="font-semibold">食材</h2>
+        <p>{recipe.ingredients}</p>
+      </div>
+      <div>
+        <h2 className="font-semibold">步驟</h2>
+        <p>{recipe.steps}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function RecipeForm() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [ingredients, setIngredients] = useState('');
+  const [steps, setSteps] = useState('');
+  const [image, setImage] = useState<File | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('name', name);
+    formData.append('ingredients', ingredients);
+    formData.append('steps', steps);
+    if (image) formData.append('image', image);
+
+    await fetch('/api/recipes', {
+      method: 'POST',
+      body: formData,
+    });
+
+    router.push('/');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block mb-1">名稱</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full border px-2 py-1"
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">食材</label>
+        <textarea
+          value={ingredients}
+          onChange={(e) => setIngredients(e.target.value)}
+          className="w-full border px-2 py-1"
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">步驟</label>
+        <textarea
+          value={steps}
+          onChange={(e) => setSteps(e.target.value)}
+          className="w-full border px-2 py-1"
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">照片</label>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setImage(e.target.files?.[0] || null)}
+        />
+      </div>
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
+        新增食譜
+      </button>
+    </form>
+  );
+}

--- a/src/components/RecipeList.tsx
+++ b/src/components/RecipeList.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import { Recipe } from '@/types/recipe';
+
+export default function RecipeList({ recipes }: { recipes: Recipe[] }) {
+  return (
+    <ul className="space-y-2">
+      {recipes.map((recipe) => (
+        <li key={recipe.id} className="border p-2 bg-white">
+          <Link href={`/recipes/${recipe.id}`}>{recipe.name}</Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/uploadImage.ts
+++ b/src/lib/uploadImage.ts
@@ -1,0 +1,24 @@
+import { supabase } from './supabaseClient';
+
+export async function uploadRecipeImage(file: File): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from('recipe-images')
+    .upload(`${Date.now()}-${file.name}`, file, {
+      cacheControl: '3600',
+      upsert: false,
+    });
+
+  if (error || !data) {
+    throw error || new Error('Upload failed');
+  }
+
+  const { data: publicUrlData } = await supabase.storage
+    .from('recipe-images')
+    .getPublicUrl(data.path);
+
+  if (!publicUrlData.publicUrl) {
+    throw new Error('Failed to get public URL');
+  }
+
+  return publicUrlData.publicUrl;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,10 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.recipes (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  ingredients text not null,
+  steps text not null,
+  "imageUrl" text not null,
+  created_at timestamptz not null default now()
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/recipe.ts
+++ b/types/recipe.ts
@@ -1,0 +1,8 @@
+export interface Recipe {
+  id: string;
+  name: string;
+  ingredients: string;
+  steps: string;
+  imageUrl: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- bootstrap Next.js project with Tailwind and Prettier
- add Supabase client and env files
- define schema for recipes table
- implement image upload helper
- create Recipe type definitions
- add API routes for recipes
- build frontend pages and components

## Testing
- `pnpm install` *(fails: 403 Forbidden)*
- `pnpm dev` *(fails: next not found because dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865f419b1e483258dc9cd42c2e9be64