### PR TITLE
Implement recipe form with markdown preview

### DIFF
--- a/app/recipes/new/page.tsx
+++ b/app/recipes/new/page.tsx
@@ -4,9 +4,6 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
-
-const normalizeHeadings = (md: string) =>
-  md.replace(/^(#{1,6})(\S)/gm, '$1 $2');
 import { supabase } from '../../../lib/supabase';
 import ImageUploader from '../../../components/ImageUploader';
 
@@ -71,17 +68,20 @@ export default function NewRecipePage() {
           <textarea
             rows={10}
             className="w-full border p-2 rounded"
-            {...register('content')}
+            {...register('content', { required: '內容必填' })}
           />
+          {errors.content && (
+            <p className="text-red-500 text-sm mt-1">
+              {errors.content.message}
+            </p>
+          )}
         </div>
 
         {/* Markdown 預覽 */}
         <div>
           <label className="block font-medium mb-1">Markdown 預覽</label>
           <div className="border p-4 rounded bg-gray-50 prose">
-            <ReactMarkdown>
-              {normalizeHeadings(watch('content') || '')}
-            </ReactMarkdown>
+            <ReactMarkdown>{watch('content') || ''}</ReactMarkdown>
           </div>
         </div>
 

--- a/app/recipes/new/page.tsx
+++ b/app/recipes/new/page.tsx
@@ -37,7 +37,8 @@ export default function NewRecipePage() {
         return;
       }
 
-      // 成功後導向列表頁
+      // 成功提示並導向列表頁
+      alert('新增成功！');
       router.push('/');
     } catch (err) {
       console.error(err);

--- a/app/recipes/new/page.tsx
+++ b/app/recipes/new/page.tsx
@@ -1,10 +1,96 @@
-import ImageUploader from '../../../components/ImageUploader';
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useRouter } from 'next/navigation'
+import ReactMarkdown from 'react-markdown'
+import { supabase } from '../../../lib/supabase'
+import ImageUploader from '../../../components/ImageUploader'
+
+type FormValues = {
+  title: string
+  content: string
+  imageUrl: string
+}
 
 export default function NewRecipePage() {
+  const router = useRouter()
+  const { register, handleSubmit, watch, formState: { errors } } = useForm<FormValues>()
+  const [imageUrl, setImageUrl] = useState('')
+
+  const onSubmit = async (data: FormValues) => {
+    try {
+      const { error } = await supabase.from('recipes').insert({
+        title: data.title,
+        content: data.content,
+        image_url: imageUrl || null
+      })
+
+      if (error) {
+        console.error(error)
+        alert('新增失敗')
+        return
+      }
+
+      // 成功後導向列表頁
+      router.push('/')
+    } catch (err) {
+      console.error(err)
+      alert('發生錯誤')
+    }
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">新增食譜</h1>
-      <ImageUploader />
+    <div className="max-w-2xl mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-6">新增食譜</h1>
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
+        {/* 標題輸入 */}
+        <div>
+          <label className="block font-medium mb-1">標題</label>
+          <input
+            type="text"
+            className="w-full border p-2 rounded"
+            {...register('title', { required: '標題必填' })}
+          />
+          {errors.title && <p className="text-red-500 text-sm mt-1">{errors.title.message}</p>}
+        </div>
+
+        {/* Markdown 輸入框 */}
+        <div>
+          <label className="block font-medium mb-1">內容 (Markdown)</label>
+          <textarea
+            rows={10}
+            className="w-full border p-2 rounded"
+            {...register('content')}
+          />
+        </div>
+
+        {/* Markdown 預覽 */}
+        <div>
+          <label className="block font-medium mb-1">Markdown 預覽</label>
+          <div className="border p-4 rounded bg-gray-50 prose">
+            <ReactMarkdown>{watch('content') || ''}</ReactMarkdown>
+          </div>
+        </div>
+
+        {/* 圖片上傳 */}
+        <div>
+          <label className="block font-medium mb-1">封面照片</label>
+          <ImageUploader
+            onUploaded={(url) => setImageUrl(url)}
+          />
+          {imageUrl && (
+            <img src={imageUrl} alt="Uploaded" className="w-48 mt-2 rounded" />
+          )}
+        </div>
+
+        <button
+          type="submit"
+          className="bg-green-600 text-white py-2 px-4 rounded hover:bg-green-700"
+        >
+          新增食譜
+        </button>
+      </form>
     </div>
-  );
+  )
 }

--- a/app/recipes/new/page.tsx
+++ b/app/recipes/new/page.tsx
@@ -1,44 +1,52 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { useRouter } from 'next/navigation'
-import ReactMarkdown from 'react-markdown'
-import { supabase } from '../../../lib/supabase'
-import ImageUploader from '../../../components/ImageUploader'
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+
+const normalizeHeadings = (md: string) =>
+  md.replace(/^(#{1,6})(\S)/gm, '$1 $2');
+import { supabase } from '../../../lib/supabase';
+import ImageUploader from '../../../components/ImageUploader';
 
 type FormValues = {
-  title: string
-  content: string
-  imageUrl: string
-}
+  title: string;
+  content: string;
+  imageUrl: string;
+};
 
 export default function NewRecipePage() {
-  const router = useRouter()
-  const { register, handleSubmit, watch, formState: { errors } } = useForm<FormValues>()
-  const [imageUrl, setImageUrl] = useState('')
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>();
+  const [imageUrl, setImageUrl] = useState('');
 
   const onSubmit = async (data: FormValues) => {
     try {
       const { error } = await supabase.from('recipes').insert({
         title: data.title,
         content: data.content,
-        image_url: imageUrl || null
-      })
+        image_url: imageUrl || null,
+      });
 
       if (error) {
-        console.error(error)
-        alert('新增失敗')
-        return
+        console.error(error);
+        alert('新增失敗');
+        return;
       }
 
       // 成功後導向列表頁
-      router.push('/')
+      router.push('/');
     } catch (err) {
-      console.error(err)
-      alert('發生錯誤')
+      console.error(err);
+      alert('發生錯誤');
     }
-  }
+  };
 
   return (
     <div className="max-w-2xl mx-auto p-8">
@@ -52,7 +60,9 @@ export default function NewRecipePage() {
             className="w-full border p-2 rounded"
             {...register('title', { required: '標題必填' })}
           />
-          {errors.title && <p className="text-red-500 text-sm mt-1">{errors.title.message}</p>}
+          {errors.title && (
+            <p className="text-red-500 text-sm mt-1">{errors.title.message}</p>
+          )}
         </div>
 
         {/* Markdown 輸入框 */}
@@ -69,16 +79,16 @@ export default function NewRecipePage() {
         <div>
           <label className="block font-medium mb-1">Markdown 預覽</label>
           <div className="border p-4 rounded bg-gray-50 prose">
-            <ReactMarkdown>{watch('content') || ''}</ReactMarkdown>
+            <ReactMarkdown>
+              {normalizeHeadings(watch('content') || '')}
+            </ReactMarkdown>
           </div>
         </div>
 
         {/* 圖片上傳 */}
         <div>
           <label className="block font-medium mb-1">封面照片</label>
-          <ImageUploader
-            onUploaded={(url) => setImageUrl(url)}
-          />
+          <ImageUploader onUploaded={(url) => setImageUrl(url)} />
           {imageUrl && (
             <img src={imageUrl} alt="Uploaded" className="w-48 mt-2 rounded" />
           )}
@@ -92,5 +102,5 @@ export default function NewRecipePage() {
         </button>
       </form>
     </div>
-  )
+  );
 }

--- a/components/ImageUploader.tsx
+++ b/components/ImageUploader.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { useState } from 'react';
 import { uploadImage } from '../lib/uploadImage';

--- a/components/ImageUploader.tsx
+++ b/components/ImageUploader.tsx
@@ -3,7 +3,11 @@
 import { useState } from 'react';
 import { uploadImage } from '../lib/uploadImage';
 
-export default function ImageUploader() {
+export default function ImageUploader({
+  onUploaded,
+}: {
+  onUploaded?: (url: string) => void;
+}) {
   const [progress, setProgress] = useState<number | null>(null);
   const [imageUrl, setImageUrl] = useState<string>('');
 
@@ -19,6 +23,9 @@ export default function ImageUploader() {
       });
 
       setImageUrl(url);
+      if (onUploaded) {
+        onUploaded(url);
+      }
     } catch (err) {
       console.error(err);
       alert('上傳失敗！');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "@supabase/supabase-js": "latest"
+    "@supabase/supabase-js": "latest",
+    "react-hook-form": "latest",
+    "react-markdown": "latest"
   },
   "devDependencies": {
     "typescript": "latest",


### PR DESCRIPTION
## Summary
- add `react-hook-form` and `react-markdown` to dependencies
- implement `app/recipes/new/page.tsx` with form for creating recipes
- enhance `ImageUploader` to emit uploaded image URL

## Testing
- `pnpm add react-hook-form react-markdown` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686747fe28f88325a1662fd3e77d8808