### PR TITLE
Implement recipe search

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ npm run dev
 ### Environment variables
 
 Copy `.env.example` to `.env.local` and fill in your Supabase credentials before running the dev server.
+
+## Features
+
+- Browse recipes with sorting controls
+- Search recipes by keyword in the title or content

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,3 +1,7 @@
 export default function Loading() {
-  return <p className="p-8">載入中...</p>;
+  return (
+    <div className="p-8 flex justify-center">
+      <p className="animate-pulse text-gray-600">載入中...</p>
+    </div>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ export default async function HomePage({
     .order('created_at', { ascending: sort === 'asc' });
 
   if (keyword) {
-    query = query.ilike('title', `%${keyword}%`);
+    query = query.or(`title.ilike.%${keyword}%,content.ilike.%${keyword}%`);
   }
 
   const { data, error } = await query;
@@ -91,7 +91,10 @@ export default async function HomePage({
                 </h2>
                 <p className="text-sm text-gray-600 overflow-hidden text-ellipsis whitespace-nowrap">
                   {recipe.content
-                    ? recipe.content.replace(/\n/g, ' ').slice(0, 50) + '...'
+                    ? highlight(
+                        recipe.content.replace(/\n/g, ' ').slice(0, 50) +
+                          (recipe.content.length > 50 ? '...' : '')
+                      )
                     : ''}
                 </p>
               </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { supabase } from '../lib/supabase';
 import Link from 'next/link';
 import SortToggle from '../components/SortToggle';
+import SearchBox from '../components/SearchBox';
 
 type Recipe = {
   id: string;
@@ -12,26 +13,49 @@ type Recipe = {
 export default async function HomePage({
   searchParams,
 }: {
-  searchParams: { sort?: string } | Promise<{ sort?: string }>;
+  searchParams:
+    | { sort?: string; q?: string }
+    | Promise<{ sort?: string; q?: string }>;
 }) {
   const params = await searchParams;
   const sort = params?.sort === 'asc' ? 'asc' : 'desc';
-
-  const { data, error } = await supabase
+  const keyword = params?.q || '';
+  let query = supabase
     .from('recipes')
     .select('id, title, content, image_url')
     .order('created_at', { ascending: sort === 'asc' });
+
+  if (keyword) {
+    query = query.ilike('title', `%${keyword}%`);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     console.error(error);
     return <p className="text-red-500 p-4">載入食譜失敗</p>;
   }
 
+  const highlight = (text: string) => {
+    if (!keyword) return text;
+    const parts = text.split(new RegExp(`(${keyword})`, 'gi'));
+    return parts.map((part, i) =>
+      part.toLowerCase() === keyword.toLowerCase() ? (
+        <mark key={i} className="bg-yellow-200">
+          {part}
+        </mark>
+      ) : (
+        part
+      )
+    );
+  };
+
   return (
     <main className="max-w-4xl mx-auto p-8">
-      <div className="flex items-center justify-between mb-6">
+      <div className="mb-6 space-y-4 sm:space-y-0 sm:flex sm:items-center sm:justify-between">
         <h1 className="text-3xl font-bold">食譜列表</h1>
-        <div className="flex items-center space-x-4">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-4 space-y-2 sm:space-y-0">
+          <SearchBox />
           <SortToggle sort={sort} />
           <Link
             href="/recipes/new"
@@ -43,6 +67,9 @@ export default async function HomePage({
       </div>
 
       <div className="space-y-4">
+        {data && data.length === 0 && (
+          <p className="text-center text-gray-500">無結果</p>
+        )}
         {data?.map((recipe) => (
           <Link
             key={recipe.id}
@@ -59,7 +86,9 @@ export default async function HomePage({
 
             <div className="p-4 flex flex-col justify-between">
               <div>
-                <h2 className="text-lg font-semibold mb-2">{recipe.title}</h2>
+                <h2 className="text-lg font-semibold mb-2">
+                  {highlight(recipe.title)}
+                </h2>
                 <p className="text-sm text-gray-600 overflow-hidden text-ellipsis whitespace-nowrap">
                   {recipe.content
                     ? recipe.content.replace(/\n/g, ' ').slice(0, 50) + '...'

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 export default function SearchBox() {
@@ -8,6 +8,11 @@ export default function SearchBox() {
   const searchParams = useSearchParams();
   const [keyword, setKeyword] = useState(searchParams.get('q') || '');
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setKeyword(searchParams.get('q') || '');
+    setLoading(false);
+  }, [searchParams]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -40,7 +40,13 @@ export default function SearchBox() {
         {keyword && (
           <button
             type="button"
-            onClick={() => setKeyword('')}
+            onClick={() => {
+              setKeyword('');
+              const params = new URLSearchParams(searchParams.toString());
+              params.delete('q');
+              setLoading(true);
+              router.push(`/?${params.toString()}`);
+            }}
             className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600"
             aria-label="清除搜尋"
           >

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -28,14 +28,26 @@ export default function SearchBox() {
 
   return (
     <form onSubmit={handleSubmit} className="flex w-full sm:w-auto space-x-2">
-      <input
-        type="text"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-        placeholder="搜尋食譜"
-        className="border p-2 rounded flex-1"
-        disabled={loading}
-      />
+      <div className="relative flex-1">
+        <input
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="搜尋食譜"
+          className="border p-2 rounded w-full pr-8"
+          disabled={loading}
+        />
+        {keyword && (
+          <button
+            type="button"
+            onClick={() => setKeyword('')}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+            aria-label="清除搜尋"
+          >
+            ×
+          </button>
+        )}
+      </div>
       <button
         type="submit"
         className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 disabled:opacity-60"

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -7,6 +7,7 @@ export default function SearchBox() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [keyword, setKeyword] = useState(searchParams.get('q') || '');
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -16,6 +17,7 @@ export default function SearchBox() {
     } else {
       params.delete('q');
     }
+    setLoading(true);
     router.push(`/?${params.toString()}`);
   };
 
@@ -27,12 +29,14 @@ export default function SearchBox() {
         onChange={(e) => setKeyword(e.target.value)}
         placeholder="搜尋食譜"
         className="border p-2 rounded flex-1"
+        disabled={loading}
       />
       <button
         type="submit"
-        className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700"
+        className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 disabled:opacity-60"
+        disabled={loading}
       >
-        搜尋
+        {loading ? '搜尋中...' : '搜尋'}
       </button>
     </form>
   );

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function SearchBox() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState(searchParams.get('q') || '');
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const params = new URLSearchParams(searchParams.toString());
+    if (keyword) {
+      params.set('q', keyword);
+    } else {
+      params.delete('q');
+    }
+    router.push(`/?${params.toString()}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full sm:w-auto space-x-2">
+      <input
+        type="text"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        placeholder="搜尋食譜"
+        className="border p-2 rounded flex-1"
+      />
+      <button
+        type="submit"
+        className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700"
+      >
+        搜尋
+      </button>
+    </form>
+  );
+}

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -30,6 +30,11 @@ export default function SearchBox() {
     navigateWithQuery(keyword);
   };
 
+  const handleClear = () => {
+    setKeyword('');
+    navigateWithQuery('');
+  };
+
   return (
     <form onSubmit={handleSubmit} className="flex w-full sm:w-auto space-x-2">
       <div className="relative flex-1">
@@ -44,10 +49,7 @@ export default function SearchBox() {
         {keyword && (
           <button
             type="button"
-            onClick={() => {
-              setKeyword('');
-              navigateWithQuery('');
-            }}
+            onClick={handleClear}
             className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600"
             aria-label="清除搜尋"
           >

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -9,6 +9,17 @@ export default function SearchBox() {
   const [keyword, setKeyword] = useState(searchParams.get('q') || '');
   const [loading, setLoading] = useState(false);
 
+  const navigateWithQuery = (kw: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (kw) {
+      params.set('q', kw);
+    } else {
+      params.delete('q');
+    }
+    setLoading(true);
+    router.push(`/?${params.toString()}`);
+  };
+
   useEffect(() => {
     setKeyword(searchParams.get('q') || '');
     setLoading(false);
@@ -16,14 +27,7 @@ export default function SearchBox() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const params = new URLSearchParams(searchParams.toString());
-    if (keyword) {
-      params.set('q', keyword);
-    } else {
-      params.delete('q');
-    }
-    setLoading(true);
-    router.push(`/?${params.toString()}`);
+    navigateWithQuery(keyword);
   };
 
   return (
@@ -42,10 +46,7 @@ export default function SearchBox() {
             type="button"
             onClick={() => {
               setKeyword('');
-              const params = new URLSearchParams(searchParams.toString());
-              params.delete('q');
-              setLoading(true);
-              router.push(`/?${params.toString()}`);
+              navigateWithQuery('');
             }}
             className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600"
             aria-label="清除搜尋"

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -41,7 +41,7 @@ export default function SearchBox() {
           <button
             type="button"
             onClick={() => setKeyword('')}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+            className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600"
             aria-label="清除搜尋"
           >
             ×


### PR DESCRIPTION
## Summary
- add `SearchBox` client component for handling search keyword input
- support `q` search param in home page
- query recipes with `ilike` when keyword is present
- show message if no results and highlight matched keywords

## Testing
- `npx prettier --write app/page.tsx components/SearchBox.tsx`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870857736888325a1e5cc4fc27c7cd2