### PR TITLE
feat: improve recipe page UI

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,7 +1,27 @@
 export default function Loading() {
   return (
-    <div className="p-8 flex justify-center">
-      <p className="animate-pulse text-gray-600">載入中...</p>
-    </div>
+    <main className="max-w-4xl mx-auto p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="h-9 w-40 bg-gray-200 rounded animate-pulse"></div>
+        <div className="flex items-center space-x-4">
+          <div className="h-9 w-40 bg-gray-200 rounded animate-pulse"></div>
+          <div className="h-9 w-20 bg-gray-200 rounded animate-pulse"></div>
+          <div className="h-9 w-28 bg-gray-200 rounded animate-pulse"></div>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="flex bg-white rounded-lg overflow-hidden shadow-md animate-pulse">
+            <div className="w-40 h-40 bg-gray-200"></div>
+            <div className="p-4 flex-grow">
+              <div className="h-6 w-3/4 bg-gray-200 rounded mb-3"></div>
+              <div className="h-4 w-full bg-gray-200 rounded mb-2"></div>
+              <div className="h-4 w-5/6 bg-gray-200 rounded"></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ export default async function HomePage({
           <Link
             key={recipe.id}
             href={`/recipes/${recipe.id}`}
-            className="flex border rounded overflow-hidden hover:shadow transition"
+            className="flex bg-white rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300"
           >
             {recipe.image_url && (
               <img

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -25,35 +25,43 @@ export default async function RecipeDetailPage({ params }: Props) {
   }
 
   return (
-    <main className="max-w-2xl mx-auto p-8">
-      {data.image_url && (
-        <img
-          src={data.image_url}
-          alt={data.title}
-          className="w-full h-auto rounded mb-6"
-        />
-      )}
+    <main className="max-w-6xl mx-auto p-4 sm:p-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12">
+        {/* Left Column: Image */}
+        <div className="w-full md:sticky md:top-8 self-start">
+          {data.image_url && (
+            <img
+              src={data.image_url}
+              alt={data.title}
+              className="w-full h-auto rounded-lg shadow-lg object-cover md:max-h-[70vh]"
+            />
+          )}
+        </div>
 
-      <h1 className="text-3xl font-bold mb-4">{data.title}</h1>
-      <div className="flex space-x-2 mb-4">
-        <Link
-          href="/"
-          className="bg-gray-500 text-white py-2 px-4 rounded hover:bg-gray-600"
-        >
-          返回
-        </Link>
-        <Link
-          href={`/recipes/${data.id}/edit`}
-          className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700"
-        >
-          編輯
-        </Link>
-        <DeleteRecipeButton recipeId={data.id} />
+        {/* Right Column: Content */}
+        <div>
+          <div className="flex space-x-2 mb-4">
+            <Link
+              href="/"
+              className="bg-gray-500 text-white py-2 px-4 rounded hover:bg-gray-600 transition-colors"
+            >
+              返回
+            </Link>
+            <Link
+              href={`/recipes/${data.id}/edit`}
+              className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 transition-colors"
+            >
+              編輯
+            </Link>
+            <DeleteRecipeButton recipeId={data.id} />
+          </div>
+          <h1 className="text-4xl font-extrabold mb-4 tracking-tight">{data.title}</h1>
+          
+          <article className="markdown">
+            <ReactMarkdown>{data.content || ''}</ReactMarkdown>
+          </article>
+        </div>
       </div>
-
-      <article className="markdown">
-        <ReactMarkdown>{data.content || ''}</ReactMarkdown>
-      </article>
     </main>
   );
 }

--- a/package.json
+++ b/package.json
@@ -10,22 +10,22 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@supabase/supabase-js": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "@supabase/supabase-js": "latest",
     "react-hook-form": "latest",
     "react-markdown": "latest"
   },
   "devDependencies": {
-    "typescript": "latest",
+    "@tailwindcss/postcss": "latest",
+    "autoprefixer": "latest",
     "eslint": "latest",
     "eslint-config-next": "latest",
-    "tailwindcss": "latest",
     "postcss": "latest",
-    "autoprefixer": "latest",
-    "@tailwindcss/postcss": "latest",
-    "prettier": "latest"
+    "prettier": "latest",
+    "tailwindcss": "latest",
+    "typescript": "latest"
   },
   "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912"
 }


### PR DESCRIPTION
---

## Summary

- **改善食譜詳細頁面 (`/recipes/[id]`)**
  - 將版面重新設計為兩欄式格線佈局，提升閱讀體驗。
  - 左欄為食譜圖片，在桌面版瀏覽時會固定在頁面上方 (sticky)，方便使用者隨時對照。
  - 右欄為食譜標題、操作按鈕和內容。
  - 優化了圖片陰影、標題字體大小等視覺樣式。

- **優化首頁 (`/`) 食譜卡片樣式**
  - 為食譜卡片增加更現代化的陰影和滑鼠懸停效果，提升視覺質感。

- **新增載入中 (Loading) 的骨架畫面**
  - 將原有的「載入中...」文字提示替換為更友善的骨架畫面 (Skeleton UI)。
  - 此畫面會模擬真實頁面的排版，降低使用者在等待資料載入時的焦慮感。

## How to test

1.  **驗證食譜詳細頁面**
    - **位置**: 隨意點進任何一則食譜的詳細頁，例如 `/recipes/some-id`。
    - **操作步驟**:
        1. 觀察頁面是否呈現左邊圖片、右邊內容的兩欄式佈局。
        2. 在桌面瀏覽器上，上下滾動頁面。
    - **預期結果**:
        1. 頁面應為新的兩欄式設計。
        2. 滾動時，左側的圖片會固定在原位，不會跟著滾動。

2.  **驗證首頁卡片樣式**
    - **位置**: 前往首頁 (`/`)。
    - **操作步驟**: 將滑鼠移動到任一食譜卡片上。
    - **預期結果**: 卡片的陰影會變得更深，且有平滑的過渡動畫效果。

3.  **驗證載入中畫面**
    - **位置**: 首頁 (`/`)。
    - **操作步驟**:
        1. 打開瀏覽器的開發者工具。
        2. 將網路速度設定為 "Slow 3G" 或類似的慢速網路。
        3. 重新整理首頁。
    - **預期結果**: 在食譜資料載入完成前，會先看到一個模擬頁面排版的灰色區塊骨架，而非僅顯示「載入中...」文字。

## 注意事項

- 本次修改皆為前端 UI 調整，不涉及後端邏輯。
- 不需要更新 `.env` 環境變數。
- 不需要執行資料庫遷移 (migration) 或重啟服務。
- 修改範圍皆在頁面元件內，預期不會影響到其他功能。

---