### PR TITLE
feat: 實現食譜詳情頁面現代化設計

### DIFF
--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -3,6 +3,8 @@ import ReactMarkdown from 'react-markdown';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import DeleteRecipeButton from '../../../components/DeleteRecipeButton';
+import Breadcrumb from '../../../components/Breadcrumb';
+// 暫時使用 emoji 替代圖標，避免模組載入問題
 
 type Props = {
   params: Promise<{
@@ -24,46 +26,91 @@ export default async function RecipeDetailPage({ params }: Props) {
     notFound();
   }
 
-  return (
-    <main className="max-w-6xl mx-auto p-4 sm:p-8">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12">
-        {/* Left Column: Image */}
-        <div className="w-full md:sticky md:top-8 self-start">
-          {data.image_url && (
-            <img
-              src={data.image_url}
-              alt={data.title}
-              className="w-full h-auto rounded-lg shadow-lg object-cover md:max-h-[70vh]"
-            />
-          )}
-        </div>
+  const formattedDate = new Date(data.created_at).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
 
-        {/* Right Column: Content */}
-        <div>
-          <div className="flex space-x-2 mb-4">
-            <Link
-              href="/"
-              className="bg-gray-500 text-white py-2 px-4 rounded hover:bg-gray-600 transition-colors"
-            >
-              返回
-            </Link>
-            <Link
-              href={`/recipes/${data.id}/edit`}
-              className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 transition-colors"
-            >
-              編輯
-            </Link>
-            <DeleteRecipeButton recipeId={data.id} />
-          </div>
-          <h1 className="text-4xl font-extrabold mb-4 tracking-tight">
+  const breadcrumbItems = [
+    { label: '首頁', href: '/' },
+    { label: '食譜詳情' }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Hero Section */}
+      <div className="bg-gradient-to-br from-orange-400 via-orange-500 to-red-500 text-white">
+        <div className="max-w-6xl mx-auto px-4 py-8 sm:px-8">
+          <Breadcrumb items={breadcrumbItems} />
+          <h1 className="text-3xl md:text-4xl font-bold mt-4 drop-shadow-md">
             {data.title}
           </h1>
-
-          <article className="markdown">
-            <ReactMarkdown>{data.content || ''}</ReactMarkdown>
-          </article>
+          <div className="flex items-center gap-4 mt-3 text-white/90">
+            <div className="flex items-center gap-1">
+              <span className="text-sm">📅</span>
+              <span className="text-sm">{formattedDate}</span>
+            </div>
+          </div>
         </div>
       </div>
-    </main>
+
+      {/* Main Content */}
+      <main className="max-w-6xl mx-auto p-4 sm:p-8">
+        {/* Action Buttons */}
+        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-8">
+          <Link
+            href="/"
+            className="flex items-center justify-center gap-2 bg-gradient-to-r from-orange-400 to-orange-500 text-white font-medium rounded-lg text-sm px-5 py-2.5 hover:from-orange-500 hover:to-orange-600 focus:ring-4 focus:outline-none focus:ring-orange-300 transition-all duration-300 transform hover:scale-105 shadow-md w-full sm:w-auto"
+          >
+            <span>←</span>
+            返回
+          </Link>
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+            <Link
+              href={`/recipes/${data.id}/edit`}
+              className="flex items-center justify-center gap-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white font-medium rounded-lg text-sm px-5 py-2.5 hover:from-blue-600 hover:to-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 transition-all duration-300 transform hover:scale-105 shadow-md w-full sm:w-auto"
+            >
+              <span>✏️</span>
+              編輯
+            </Link>
+            <div className="w-full sm:w-auto">
+              <DeleteRecipeButton recipeId={data.id} />
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12">
+          {/* Left Column: Image */}
+          <div className="w-full lg:sticky lg:top-8 self-start">
+            <div className="bg-white rounded-xl shadow-lg overflow-hidden">
+              {data.image_url ? (
+                <img
+                  src={data.image_url}
+                  alt={data.title}
+                  className="w-full h-auto object-cover lg:max-h-[70vh]"
+                />
+              ) : (
+                <div className="w-full h-64 bg-gray-100 flex items-center justify-center">
+                  <div className="text-center text-gray-500">
+                    <div className="text-4xl mb-2">🍳</div>
+                    <p>暫無圖片</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right Column: Content */}
+          <div>
+            <div className="bg-white rounded-xl shadow-lg p-6 lg:p-8">
+              <article className="markdown prose-orange">
+                <ReactMarkdown>{data.content || ''}</ReactMarkdown>
+              </article>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
   );
 }

--- a/components/Breadcrumb.tsx
+++ b/components/Breadcrumb.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav className="flex items-center text-sm text-white/80">
+      {items.map((item, index) => (
+        <div key={index} className="flex items-center">
+          {item.href ? (
+            <Link href={item.href} className="hover:text-white">
+              {item.label}
+            </Link>
+          ) : (
+            <span className="font-medium text-white">{item.label}</span>
+          )}
+          {index < items.length - 1 && (
+            <span className="mx-1">›</span>
+          )}
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+// 使用原生符號替代圖標
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmText?: string;
+  cancelText?: string;
+  isLoading?: boolean;
+}
+
+export default function ConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmText = '確認',
+  cancelText = '取消',
+  isLoading = false,
+}: ConfirmModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-md transform transition-all">
+        <div className="p-6">
+          <div className="flex items-start">
+            <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+              <span className="text-2xl text-red-600">⚠️</span>
+            </div>
+            <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 className="text-lg leading-6 font-medium text-gray-900">{title}</h3>
+              <div className="mt-2">
+                <p className="text-sm text-gray-500">{description}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse rounded-b-lg">
+          <button
+            type="button"
+            disabled={isLoading}
+            className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+            onClick={onConfirm}
+          >
+            {isLoading ? '處理中...' : confirmText}
+          </button>
+          <button
+            type="button"
+            className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            {cancelText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/DeleteRecipeButton.tsx
+++ b/components/DeleteRecipeButton.tsx
@@ -3,14 +3,16 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '../lib/supabase';
+import ConfirmModal from './ConfirmModal';
+// 使用原生符號替代圖標
 
 export default function DeleteRecipeButton({ recipeId }: { recipeId: string }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleDelete = async () => {
-    if (!confirm('確定要刪除嗎？')) return;
+  const handleConfirmDelete = async () => {
     setLoading(true);
     setError(null);
 
@@ -23,22 +25,33 @@ export default function DeleteRecipeButton({ recipeId }: { recipeId: string }) {
       console.error(error);
       setError('刪除失敗');
       setLoading(false);
+      setIsModalOpen(false);
       return;
     }
 
     router.push('/');
+    router.refresh(); // Refresh the page to reflect the deletion
   };
 
   return (
-    <div>
+    <>
       <button
-        onClick={handleDelete}
+        onClick={() => setIsModalOpen(true)}
         disabled={loading}
-        className="bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 disabled:opacity-50"
+        className="flex items-center justify-center gap-2 w-full sm:w-auto text-white font-medium rounded-lg text-sm px-5 py-2.5 text-center bg-gradient-to-r from-red-500 to-orange-500 hover:from-red-600 hover:to-orange-600 focus:ring-4 focus:outline-none focus:ring-red-300 transition-all duration-300 transform hover:scale-105 shadow-md"
       >
+        <span>🗑️</span>
         {loading ? '刪除中...' : '刪除'}
       </button>
-      {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
-    </div>
+      {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+      <ConfirmModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleConfirmDelete}
+        title="確認刪除"
+        description="您確定要刪除這篇食譜嗎？此操作無法復原。"
+        isLoading={loading}
+      />
+    </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,28 +1,98 @@
 @import 'tailwindcss';
 
-/* basic markdown styling without typography plugin */
+/* Enhanced markdown styling with orange theme */
 .markdown h1 {
-  @apply text-2xl font-bold mb-4;
+  @apply text-3xl font-bold mb-6 text-gray-900 border-b-2 border-orange-200 pb-2;
 }
 
 .markdown h2 {
-  @apply text-xl font-semibold mt-4 mb-2;
+  @apply text-2xl font-semibold mt-8 mb-4 text-gray-800 relative;
+}
+
+.markdown h2::before {
+  content: '';
+  @apply absolute -left-4 top-1/2 transform -translate-y-1/2 w-1 h-6 bg-gradient-to-b from-orange-400 to-orange-500 rounded-full;
+}
+
+.markdown h3 {
+  @apply text-xl font-semibold mt-6 mb-3 text-gray-800;
+}
+
+.markdown h4 {
+  @apply text-lg font-medium mt-4 mb-2 text-gray-800;
 }
 
 .markdown p {
-  @apply mb-4;
+  @apply mb-4 text-gray-700 leading-relaxed;
 }
 
 .markdown ul {
-  @apply list-disc pl-6 mb-4;
+  @apply list-none pl-6 mb-4 space-y-2;
+}
+
+.markdown ul li {
+  @apply relative;
+}
+
+.markdown ul li::before {
+  content: '';
+  @apply absolute -left-4 top-2 w-2 h-2 bg-orange-400 rounded-full;
 }
 
 .markdown ol {
-  @apply list-decimal pl-6 mb-4;
+  @apply list-decimal pl-6 mb-4 space-y-2;
+}
+
+.markdown ol li {
+  @apply text-gray-700 leading-relaxed;
 }
 
 .markdown a {
-  @apply text-blue-600 underline;
+  @apply text-orange-600 hover:text-orange-700 underline decoration-orange-300 hover:decoration-orange-500 transition-colors;
+}
+
+.markdown blockquote {
+  @apply border-l-4 border-orange-300 bg-orange-50 pl-4 py-2 mb-4 italic text-gray-700;
+}
+
+.markdown code {
+  @apply bg-gray-100 px-2 py-1 rounded text-sm font-mono text-gray-800;
+}
+
+.markdown pre {
+  @apply bg-gray-900 text-gray-100 p-4 rounded-lg mb-4 overflow-x-auto;
+}
+
+.markdown pre code {
+  @apply bg-transparent px-0 py-0;
+}
+
+.markdown table {
+  @apply w-full border-collapse mb-4 shadow-sm rounded-lg overflow-hidden;
+}
+
+.markdown th {
+  @apply bg-gradient-to-r from-orange-400 to-orange-500 text-white px-4 py-3 text-left font-semibold;
+}
+
+.markdown td {
+  @apply border-b border-gray-200 px-4 py-3 text-gray-700;
+}
+
+.markdown tr:nth-child(even) {
+  @apply bg-gray-50;
+}
+
+.markdown hr {
+  @apply border-0 h-px bg-gradient-to-r from-transparent via-orange-300 to-transparent my-8;
+}
+
+.markdown strong {
+  @apply font-semibold text-gray-900;
+}
+
+.markdown em {
+  @apply italic text-gray-700;
 }
 
 /* Line clamp utilities */


### PR DESCRIPTION
## Summary

- **新增 Hero 區段**：創建橙色漸層標題區域，包含麵包屑導航、食譜標題和創建日期
- **重新設計按鈕佈局**：返回按鈕置於左側，編輯/刪除按鈕組合置於右側
- **改進響應式設計**：小螢幕下按鈕垂直排列，大螢幕下水平排列，避免按鈕畸形
- **現代化視覺設計**：使用白色卡片容器、圓角陰影、漸層按鈕等現代設計元素
- **擴展 Markdown 樣式**：大幅改進內容樣式，支援表格、代碼塊、引用等，採用橙色主題
- **新增通用組件**：創建 Breadcrumb 和 ConfirmModal 組件供其他頁面使用
- **優化無圖片狀態**：改進無圖片時的視覺呈現
- **統一背景色**：使用 bg-gray-50 與列表頁面保持一致

## How to test

### 桌面端測試
1. 訪問任一食譜詳情頁面（如 `/recipes/[id]`）
2. 確認 Hero 區段顯示正確：橙色漸層背景、麵包屑導航、食譜標題、創建日期
3. 確認按鈕佈局：返回按鈕在左側，編輯和刪除按鈕在右側
4. 測試按鈕功能：返回首頁、編輯食譜、刪除食譜（確認模態框彈出）
5. 確認圖片顯示正常，無圖片時顯示預設狀態
6. 確認 Markdown 內容樣式：標題層次、列表、連結、代碼塊等

### 移動端測試
1. 縮小瀏覽器視窗或使用手機訪問
2. 確認按鈕垂直堆疊排列，寬度填滿容器
3. 確認所有按鈕保持正常形狀，無畸形問題
4. 確認響應式圖片和內容佈局正常

### 互動功能測試
1. 點擊「刪除」按鈕，確認彈出確認對話框而非原生 confirm
2. 測試確認對話框的「確認」和「取消」功能
3. 確認刪除成功後正確跳轉到首頁

## 注意事項

- **無需環境變數更新**：此次更新僅涉及前端 UI 改進
- **無需資料庫更新**：不涉及資料結構變更
- **相容性**：移除了 lucide-react 依賴，改用 emoji 圖標避免依賴問題
- **無其他模組影響**：新增的通用組件可供其他頁面復用
- **已通過構建測試**：所有變更已通過 `pnpm build` 驗證

🤖 Generated with [Claude Code](https://claude.ai/code)